### PR TITLE
Replace quote delimiters with defvars

### DIFF
--- a/hypothesis.el
+++ b/hypothesis.el
@@ -87,7 +87,7 @@ Helper function for `hypothesis-data'."
                         (or (alist-get 'location-start row2) 0)))))
     (org-insert-time-stamp (alist-get 'update-time x) t t nil "\n")
     (when-let ((highlight (alist-get 'highlight x)))
-      (insert (format "%s\n%s\n%s\n"
+      (insert (format "%s\n%s\n%s"
                       hypothesis-quote-prefix
 		      highlight
                       hypothesis-quote-sufix)))

--- a/hypothesis.el
+++ b/hypothesis.el
@@ -28,6 +28,11 @@
 (defvar hypothesis-archive (expand-file-name "hypothesis.org" org-directory)
   "File which `hypothesis-to-archive' imports data into.")
 
+(defvar hypothesis-quote-prefix "#+BEGIN_QUOTE"
+  "Prefix for block quote.")
+(defvar hypothesis-quote-sufix "#+END_QUOTE"
+  "Suffix for block quote.")
+
 (defvar hypothesis--site-level 1)
 (defvar hypothesis--last-update nil)
 
@@ -82,7 +87,10 @@ Helper function for `hypothesis-data'."
                         (or (alist-get 'location-start row2) 0)))))
     (org-insert-time-stamp (alist-get 'update-time x) t t nil "\n")
     (when-let ((highlight (alist-get 'highlight x)))
-      (insert (format "#+BEGIN_QUOTE\n%s\n#+END_QUOTE" highlight)))
+      (insert (format "%s\n%s\n%s\n"
+                      hypothesis-quote-prefix
+		      highlight
+                      hypothesis-quote-sufix)))
     (when (eq 'annotation (alist-get 'type x))
       (insert "\n\n- "))
     (insert (concat (alist-get 'text x) "\n\n\n"))))


### PR DESCRIPTION
Thanks for hypothesis.el, I really like it!

I don't know when exactly, but a couple of updates ago, Org-mode block delimiters changed to lower case letters, so `#+BEGIN_QUOTE` changed to `#+begin_quote`.

This PR introduces `hypothesis-quote-prefix` and `hypothesis-quote-sufix` to format
the quote block delimiters as one wishes. The defaults are still capitalized.