### PR TITLE
Use the new official url of hypothesis

### DIFF
--- a/hypothesis.el
+++ b/hypothesis.el
@@ -103,7 +103,7 @@ PARAMS is an alist of the uri parameters sent in the request.
 However the `hypothesis-username' is also included unless EXCLUDE-USER is t."
   (if (and hypothesis-username hypothesis-token)
       (request
-        "http://hypothes.is/api/search"
+        "https://api.hypothes.is/api/search"
         :parser 'json-read
         :params (append params (unless exclude-user
                                  `(("user" . ,(format "acct:%s@hypothes.is"


### PR DESCRIPTION
Strangely, the url http://hypothes.is still work but returns a subset of my annotations.

I actually tried the following

- curl http://hypothes.is returns a subset of my annotation (only 26 out of 4203)
- python's requests module does the same
- httpie returns all the annotations

Using https://api.hypothes.is, curl and http return the correct number of annotation, while python's requests module still returns the subset.

But, as long as curl works fine, I guess it's ok as far as hypothesis.el is concerned.