### PR TITLE
fix: wrong api host

### DIFF
--- a/hypothesis.el
+++ b/hypothesis.el
@@ -103,7 +103,7 @@ PARAMS is an alist of the uri parameters sent in the request.
 However the `hypothesis-username' is also included unless EXCLUDE-USER is t."
   (if (and hypothesis-username hypothesis-token)
       (request
-        "http://hypothes.is/api/search"
+        "https://api.hypothes.is/api/search"
         :parser 'json-read
         :params (append params (unless exclude-user
                                  `(("user" . ,(format "acct:%s@hypothes.is"


### PR DESCRIPTION
I have noticed that the API address has changed, and requests to the old address will fail.

valid api host:

```
https://api.hypothes.is/api/search
```

EDIT：

It seems that someone has already noticed #10 this issue and analyzed it. I am unsure if the old API will actually work, but updating to the new version of the API is always a good idea, especially since it uses HTTPS.
